### PR TITLE
Prevent "insecure assets" warning over https

### DIFF
--- a/views/assets/scss/dark.scss
+++ b/views/assets/scss/dark.scss
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Carme);
+@import url(//fonts.googleapis.com/css?family=Carme);
 
 $accent: #171717;
 $background: #252525;

--- a/views/assets/scss/light.scss
+++ b/views/assets/scss/light.scss
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Carme);
+@import url(//fonts.googleapis.com/css?family=Carme);
 
 $accent: #222222;
 $background: #F5F5F5;


### PR DESCRIPTION
Prevent "insecure assets" warning over https with protocol-relative links for external assets
