### PR TITLE
Fix non-threadsafe autoloading of tilt/haml,sass

### DIFF
--- a/sharex_server.rb
+++ b/sharex_server.rb
@@ -4,8 +4,8 @@ require "sinatra/content_for"
 require "sinatra/config_file"
 require "active_support"
 require "active_support/core_ext/numeric/conversions"
-require "haml"
-require "sass"
+require "tilt/haml"
+require "tilt/sass"
 
 # Helpers
 require_relative "helpers/file_helper"


### PR DESCRIPTION
This fixes a warning when using some additional gems (my WIP repo does)